### PR TITLE
Problem to determine the Low an High

### DIFF
--- a/DN.Setup.pas
+++ b/DN.Setup.pas
@@ -76,7 +76,7 @@ var
   i: Integer;
 begin
   SetLength(Result, Length(AName));
-  for i := Low(Result) to High(Result) do
+  for i := 0 to Length(Result) do
   begin
     if TPath.IsValidFileNameChar(AName[i]) then
       Result[i] := AName[i]


### PR DESCRIPTION
The commands Low and High cannot be use in strings on Delphi XE, is was
modified to use 1 and Length that have the same result.