### PR TITLE
Added names for Delphi releases before XE.

### DIFF
--- a/DN.PackageDetailView.pas
+++ b/DN.PackageDetailView.pas
@@ -69,8 +69,9 @@ uses
 {$R *.dfm}
 
 const
-  CDelphiNames: array[22..29] of string =
-  ('XE', 'XE2', 'XE3', 'XE4', 'XE5', 'XE6', 'XE7', 'XE8');
+  CDelphiNames: array[9..29] of string =
+  ('2', '3', '3', '4', '5', '6', '7', '8', '2005', '2006', '2007', '2009', '2010',
+   'XE', 'XE2', 'XE3', 'XE4', 'XE5', 'XE6', 'XE7', 'XE8');
 
   function GetDelphiName(const ACompilerVersion: TCompilerVersion): string;
   var


### PR DESCRIPTION
Although Delphinus only supports XE and newer, it is perfectly valid
scenario that a package could support older Delphis. (For example,
OmniThreadLibrary supports Delphi 2007 and newer.) It is therefor
desired that correct product name is displayed in the Package Info
dialog in that case (and not 'Delphi Compiler 19' or similar).