### PR TITLE
Fix for invisible title labels on some systems

### DIFF
--- a/DN.Preview.pas
+++ b/DN.Preview.pas
@@ -196,7 +196,7 @@ begin
 
     Canvas.Draw(CPadding, CPadding, FTarget);
     Canvas.Font.Style := [TFontStyle.fsBold];
-    Canvas.Font.Color := clCaptionText;
+    Canvas.Font.Color := clWindowText;
     Canvas.TextOut(CLeftMargin, CMargin, FPackage.Name);
     Canvas.Font.Style := [];
     Canvas.Font.Color := clGrayText;


### PR DESCRIPTION
I had a problem on Windows 7 with modified "Windows Classic" theme