### PR TITLE
Turn on WordWrap in license view

### DIFF
--- a/Packages/Delphinus.LicenseDialog.dfm
+++ b/Packages/Delphinus.LicenseDialog.dfm
@@ -28,7 +28,6 @@ object LicenseDialog: TLicenseDialog
     ReadOnly = True
     ScrollBars = ssVertical
     TabOrder = 0
-    WordWrap = False
   end
   object btnOk: TButton
     Left = 476


### PR DESCRIPTION
Turning on WordWrap makes license much more readable in extreme cases 😁 (there is only 1 scrollbar enabled)

Before this it was possible to get some 2-liiiiiiiiiiiiiiiine horror...