### PR TITLE
fixed: don't add installation entry if registry key is corrupted or invalid

### DIFF
--- a/DN.DelphiInstallation.Provider.pas
+++ b/DN.DelphiInstallation.Provider.pas
@@ -77,7 +77,10 @@ begin
       for LKey in LKeyNames do
       begin
         LInstallation := TDNDelphInstallation.Create(TPath.Combine(CRootKey, LKey));
-        FInstallations.Add(LInstallation);
+        if LInstallation.Application <> '' then
+        begin
+          FInstallations.Add(LInstallation);
+        end;
       end;
       RemoveIgnoredInstallations();
     end;


### PR DESCRIPTION
On my system was the registry key Software\Embarcadero\BDS\19.0 left, but it was empty - maybe a incomplete uninstall. But the WebSetup took this key and displayed and empty entry, where it was not clear what it is.