### PR TITLE
Fixed XE7 and lower incompatibility caused by System.ImageList #74

### DIFF
--- a/DN.PackageDetailView.pas
+++ b/DN.PackageDetailView.pas
@@ -17,7 +17,12 @@ uses
   DN.Controls,
   DN.Version,
   Delphinus.Forms,
-  ImgList, System.ImageList;
+  ImgList
+{$IFDEF CONDITIONALEXPRESSIONS}
+{$IF CompilerVersion >= 29.0}
+  ,System.ImageList
+{$IFEND}
+{$ENDIF};
 
 type
   TGetPackageVersion = function(const APackage: IDNPackage): TDNVersion of object;

--- a/Packages/Delphinus.DependencyDialog.pas
+++ b/Packages/Delphinus.DependencyDialog.pas
@@ -6,7 +6,12 @@ uses
   Windows, Messages, SysUtils, Variants, Classes, Graphics,
   Controls, Forms, Dialogs, ComCtrls,
   DN.Setup.Dependency.Intf,
-  Delphinus.Forms, ImgList, StdCtrls, System.ImageList;
+  Delphinus.Forms, ImgList, StdCtrls
+{$IFDEF CONDITIONALEXPRESSIONS}
+{$IF CompilerVersion >= 29.0}
+   , System.ImageList
+{$IFEND}
+{$ENDIF};
 
 type
   TDependencyDialog = class(TForm)

--- a/Packages/Delphinus.SetupDialog.pas
+++ b/Packages/Delphinus.SetupDialog.pas
@@ -28,7 +28,12 @@ uses
   ComCtrls,
   ExtCtrls,
   DN.ComCtrls.Helper,
-  ImgList, System.ImageList;
+  ImgList
+{$IFDEF CONDITIONALEXPRESSIONS}
+{$IF CompilerVersion >= 29.0}
+   , System.ImageList
+{$IFEND}
+{$ENDIF};
 
 const
   CStart = WM_USER + 1;


### PR DESCRIPTION
Couldn't delete the .res files in the request, so had to create a new one from stretch.
#74 