### PR TITLE
Allow directory normalisation of slashes.

### DIFF
--- a/DN.JSonFile.Info.pas
+++ b/DN.JSonFile.Info.pas
@@ -120,7 +120,7 @@ var
   LValue: TJSONValue;
 begin
   inherited;
-  FPicture := ReadString(ARoot, 'picture');
+  FPicture := NormaliseDirectoryPath(ReadString(ARoot, 'picture'));
   FID := ReadID(ARoot);
   FName := ReadString(ARoot, 'name');
   ReadLicenses(ARoot);
@@ -219,6 +219,8 @@ begin
         LObject := TJSONObject(LValue);
         LLicense.LicenseType := ReadString(LObject, 'type');
         LLicense.LicenseFile := ReadString(LObject, 'file');
+        if not LLicense.LicenseFile.StartsWith('http') then
+          LLicense.LicenseFile := NormaliseDirectoryPath(LLicense.LicenseFile);
         FLicenses[i] := LLicense;
       end;
     end;

--- a/DN.JSonFile.Info.pas
+++ b/DN.JSonFile.Info.pas
@@ -218,9 +218,7 @@ begin
       begin
         LObject := TJSONObject(LValue);
         LLicense.LicenseType := ReadString(LObject, 'type');
-        LLicense.LicenseFile := ReadString(LObject, 'file');
-        if not LLicense.LicenseFile.StartsWith('http') then
-          LLicense.LicenseFile := NormaliseDirectoryPath(LLicense.LicenseFile);
+        LLicense.LicenseFile := NormaliseDirectoryPath(ReadString(LObject, 'file'));
         FLicenses[i] := LLicense;
       end;
     end;

--- a/DN.JSonFile.Installation.pas
+++ b/DN.JSonFile.Installation.pas
@@ -174,7 +174,7 @@ begin
     for i := 0 to Pred(LArray.Count) do
     begin
       LItem := LArray.Items[i] as TJSONObject;
-      APathes[i].Path := ReadString(LItem, 'pathes');
+      APathes[i].Path := NormaliseDirectoryPath(ReadString(LItem, 'pathes'));
       LCompiler := ReadInteger(LItem, 'compiler');
       if LCompiler > 0 then
       begin
@@ -226,7 +226,7 @@ begin
   for i := 0 to Pred(ARawFolders.Count) do
   begin
     LItem := ARawFolders.Items[i] as TJSONObject;
-    FRawFolders[i].Folder := ReadString(LItem, 'folder');
+    FRawFolders[i].Folder := NormaliseDirectoryPath(ReadString(LItem, 'folder'));
     LCompiler := ReadInteger(LItem, 'compiler');
     if LCompiler > 0 then
     begin
@@ -251,8 +251,8 @@ begin
   for i := 0 to Pred(AFolders.Count) do
   begin
     LItem := AFolders.Items[i] as TJSONObject;
-    FSourceFolders[i].Folder := ReadString(LItem, 'folder');
-    FSourceFolders[i].Base := ReadString(LItem, 'base');
+    FSourceFolders[i].Folder := NormaliseDirectoryPath(ReadString(LItem, 'folder'));
+    FSourceFolders[i].Base := NormaliseDirectoryPath(ReadString(LItem, 'base'));
     FSourceFolders[i].Recursive := ReadBoolean(LItem, 'recursive');
     FSourceFolders[i].Filter := ReadString(LItem, 'filter');
     LCompiler := ReadInteger(LItem, 'compiler');

--- a/DN.Utils.pas
+++ b/DN.Utils.pas
@@ -8,6 +8,7 @@ uses
 function GetDelphiName(const ACompilerVersion: TCompilerVersion): string;
 function GenerateSupportsString(const AMin, AMax: TCompilerVersion): string;
 function GeneratePlatformString(APlatforms: TDNCompilerPlatforms; const ASeperator: string = ', '): string;
+function NormaliseDirectoryPath(const APath : string) : string;
 
 const
   TDNCompilerTargetName: array[Low(TDNCompilerTarget)..High(TDNCompilerTarget)] of string = ('Build', 'Compile');
@@ -88,6 +89,11 @@ begin
     end;
 
   Result := False;
+end;
+
+function NormaliseDirectoryPath(const APath : string) : string;
+begin
+  exit(APath.Replace('/', '\', [rfReplaceAll]));
 end;
 
 end.


### PR DESCRIPTION
Users may want to use forward slashes in config where Windows uses back slashes.

Candidates are picture, license and paths. It may not be obvious that this can cause a problem that is not obvious without clearer error messages identifying the problematic element.